### PR TITLE
Google Fonts onboarding

### DIFF
--- a/sources/BBHSans-Bartle.glyphs
+++ b/sources/BBHSans-Bartle.glyphs
@@ -6325,6 +6325,26 @@ metricWidth = "=222";
 unicode = 8287;
 },
 {
+glyphname = lineseparator;
+layers = (
+{
+layerId = "C18D3387-8030-4A68-97FB-3AF8A3E1D39D";
+width = 600;
+}
+);
+unicode = 8232;
+},
+{
+glyphname = paragraphseparator;
+layers = (
+{
+layerId = "C18D3387-8030-4A68-97FB-3AF8A3E1D39D";
+width = 600;
+}
+);
+unicode = 8233;
+},
+{
 glyphname = .notdef;
 lastChange = "2025-08-13 14:18:37 +0000";
 layers = (

--- a/sources/BBHSans-Bogle.glyphs
+++ b/sources/BBHSans-Bogle.glyphs
@@ -6244,6 +6244,26 @@ metricWidth = "=222";
 unicode = 8287;
 },
 {
+glyphname = lineseparator;
+layers = (
+{
+layerId = "39DC058D-615C-44EE-9158-2D05AB2D1C50";
+width = 600;
+}
+);
+unicode = 8232;
+},
+{
+glyphname = paragraphseparator;
+layers = (
+{
+layerId = "39DC058D-615C-44EE-9158-2D05AB2D1C50";
+width = 600;
+}
+);
+unicode = 8233;
+},
+{
 glyphname = .notdef;
 lastChange = "2025-08-13 14:18:54 +0000";
 layers = (

--- a/sources/BBHSans-Hegarty.glyphs
+++ b/sources/BBHSans-Hegarty.glyphs
@@ -10654,6 +10654,28 @@ metricWidth = "=222";
 unicode = 8287;
 },
 {
+glyphname = lineseparator;
+lastChange = "2025-08-14 08:53:38 +0000";
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+unicode = 8232;
+},
+{
+glyphname = paragraphseparator;
+lastChange = "2025-08-14 08:53:54 +0000";
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+unicode = 8233;
+},
+{
 glyphname = .notdef;
 lastChange = "2025-08-13 14:19:01 +0000";
 layers = (


### PR DESCRIPTION
Thank you for adding the extra required glyphs for Google Fonts Kernel support. Here are a few small technical changes which would help with GF onboarding:

* **Family names**: The GF system does not support custom style names, so custom styles need to be expressed as [separate families](https://googlefonts.github.io/gf-guide/statics.html#unsupported-styles). So we rename "BBHSans-Bogle" to "BBHSansBogle-Regular", etc.
* **Soft hyphens**: We recommend [not exporting the soft hyphen glyph](https://fonttools.github.io/fontspector/#soft_hyphen) as hyphenation should be handled by the text layout software.
* **Separator glyphs**: Conversely, adding paragraph separator and line separator glyphs has been reported to potentially [avoid tofu on Android](https://github.com/googlefonts/roboto-3-classic/issues/138).